### PR TITLE
add keyed list type to support hash-map style updaters

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,16 +13,17 @@ var _ = require('lodash')
   , itemFuncs = require('./lib/item-functions')
   , mapFuncs = require('./lib/map-functions')
   , listFuncs = require('./lib/list-functions')
-  , accFuncNames = _.keys(_.extend({}, itemFuncs.accessors, mapFuncs.accessors, listFuncs.accessors))
-  , mutFuncNames = _.keys(_.extend({}, itemFuncs.mutators, mapFuncs.mutators, listFuncs.mutators))
-  , funcsByType = {item:itemFuncs,map:mapFuncs,list:listFuncs}
+  , keyedListFuncs = require('./lib/keyed-list-functions')
+  , accFuncNames = _.keys(_.extend({}, itemFuncs.accessors, mapFuncs.accessors, listFuncs.accessors, keyedListFuncs.accessors))
+  , mutFuncNames = _.keys(_.extend({}, itemFuncs.mutators, mapFuncs.mutators, listFuncs.mutators, keyedListFuncs.mutators))
+  , funcsByType = {item:itemFuncs,map:mapFuncs,list:listFuncs,"keyed-list":keyedListFuncs}
   , isImmutable = require('./lib/is-immutable')
 
 // ======================================================
 // Store
 
 var makeDef = (function() {
-  var validTypes = {item:1,map:1,list:1}
+  var validTypes = {item:1,map:1,list:1,"keyed-list":1}
   function getDefault(type) {
     if (type === 'item') {
       return undefined
@@ -30,6 +31,8 @@ var makeDef = (function() {
       return {}
     } else if (type === 'list') {
       return []
+    } else if (type === 'keyed-list') {
+      return {}
     }
   }
   return function(prop, def) {

--- a/lib/keyed-list-functions.js
+++ b/lib/keyed-list-functions.js
@@ -1,0 +1,273 @@
+/* ----------------------------------------------------------
+ * @license
+ * Copyright (c) 2014-2015 Greg Reimer <gregreimer@gmail.com>
+ * Available under MIT license (see LICENSE in repo)
+ * ----------------------------------------------------------
+ */
+
+'use strict'
+
+var _ = require('lodash')
+
+module.exports = {
+
+  mutators: {
+
+    set: function(def, key, idx, val) {
+      def.validate(val)
+      var oldVal = _.cloneDeep(def.value[key]);
+      if (!def.value[key]) { def.value[key] = [] }
+      def.value[key][idx] = val
+      this._change(def, {
+        key: key,
+        newVal: def.value[key],
+        oldVal: oldVal
+      })
+    },
+
+    unset: function(def, key) {
+      var oldVal = def.value[key]
+      delete def.value[key]
+      this._change(def, {
+        key: key,
+        newVal: undefined,
+        oldVal: oldVal
+      })
+    },
+
+    splice: function(def, key) {
+      var args = Array.prototype.slice.call(arguments)
+      args.shift()
+      var oldList = def.value[key].slice()
+        ,newList = def.value[key].slice()
+      Array.prototype.splice.apply(newList, args)
+      var max = Math.max(oldList.length, newList.length)
+      def.value[key] = newList
+      for (var idx=0; idx<max; idx++) {
+        if (newList[idx] !== oldList[idx]) {
+          this._change(def, {
+            key: key,
+            newVal: newList,
+            oldVal: oldList
+          })
+        }
+      }
+    },
+
+    push: function(def, key, val) {
+      def.validate(val)
+      var oldList = _.cloneDeep(def.value[key])
+      def.value[key].push(val)
+      this._change(def, {
+        key: key,
+        newVal: def.value[key],
+        oldVal: oldList
+      })
+    },
+
+    unshift: function(def, key, val) {
+      def.validate(val)
+      var newList = def.value[key].slice()
+      newList.unshift(val)
+      var oldList = def.value
+      def.value = newList
+      this._change(def, {
+        key: key,
+        newVal: newList,
+        oldVal: oldList
+      })
+    },
+
+    pop: function(def, key) {
+      var oldList = _.cloneDeep(def.value[key])
+      var result = def.value[key].pop()
+      this._change(def, {
+        key: key,
+        newVal: def.value[key],
+        oldVal: oldList
+      })
+      return result
+    },
+
+    shift: function(def, key) {
+      var newList = def.value[key].slice()
+        ,result = newList.shift()
+        ,oldList = def.value[key]
+      def.value[key] = newList
+      this._change(def, {
+        key: key,
+        newVal: newList,
+        oldVal: oldList
+      })
+      return result
+    },
+
+    setAll: function(def, newMap) {
+      _.each(newMap, function(val) {
+        def.validate(val)
+      })
+      var oldMap = def.value
+        ,merged = _.extend({}, oldMap, newMap)
+      def.value = merged
+      _.each(newMap, function(val, key) {
+        if (newMap[key] !== oldMap[key]) {
+          this._change(def, {
+            key: key,
+            newVal: newMap[key],
+            oldVal: oldMap[key]
+          })
+        }
+      },this)
+    },
+
+    resetAll: function(def, newMap) {
+      newMap = _.extend({}, newMap)
+      _.each(newMap, function(val) {
+        def.validate(val)
+      })
+      var oldMap = def.value
+        ,merged = _.extend({}, newMap, oldMap)
+      def.value = newMap
+      _.each(merged, function(val, key) {
+        if (newMap[key] !== oldMap[key]) {
+          this._change(def, {
+            key: key,
+            newVal: newMap[key],
+            oldVal: oldMap[key]
+          })
+        }
+      },this)
+    },
+
+    setExistingValuesTo: function(def, val) {
+      var newMap = {}
+      _.each(def.value, function(value, name) {
+        newMap[name] = val
+      })
+      this.resetAll(def.prop, newMap)
+    },
+
+    clear: function(def) {
+      var oldMap = def.value
+      def.value = {}
+      _.each(oldMap, function(val, key) {
+        this._change(def, {
+          key: key,
+          newVal: undefined,
+          oldVal: oldMap[key]
+        })
+      },this)
+    },
+
+    truncateLengthAtKey: function (def, key, len) {
+      if (!def.value[key]) { def.value[key] = [] }
+      if (len >= def.value[key].length) {
+        return;
+      }
+      var newList = def.value[key].slice(0, len)
+        ,oldList = def.value[key]
+      def.value[key] = newList
+      for (var idx=newList.length; idx<oldList.length; idx++) {
+        this._change(def, {
+          key: key,
+          newVal: newList[idx],
+          oldVal: oldList[idx]
+        })
+      }
+    }
+  },
+
+  accessors: {
+
+    get: function(def, key, idx) {
+      return def.value[key] && def.value[key][idx]
+    },
+
+    getLoadable: function(def, key, idx) {
+      return {
+        value: this.get(def.prop, key, idx),
+        loading: this.get(def.prop + ':loading', key, idx),
+        status: this.get(def.prop + ':status', key, idx),
+        timestamp: this.get(def.prop + ':timestamp', key, idx),
+        code: this.get(def.prop + ':code', key, idx)
+      }
+    },
+
+    clone: function(def, key, idx, deep) {
+      return def.value[key] && _.clone(def.value[key][idx], deep)
+    },
+
+    has: function(def, key) {
+      return def.value.hasOwnProperty(key)
+    },
+
+    getAll: function(def) {
+      var copy = {}
+      for (var x in def.value) {
+        if (def.value.hasOwnProperty(x)) {
+          copy[x] = ((def.value[x].slice) ? def.value[x].slice() : _.clone(def.value[x]))
+        }
+      }
+      return copy;
+    },
+
+    getAllLoadables: function(def) {
+      var result = {}
+      const mapLoadables = function (key) {
+        result[key] = def.value[key].map(function (item, idx) {
+          return this.getLoadable(def.prop, key, idx)
+        }, this)
+      }.bind(this)
+      for (var key in def.value) {
+        if (def.value.hasOwnProperty(key)) {
+          mapLoadables(key)
+        }
+      }
+      return result
+    },
+
+    keys: function(def) {
+      return _.keys(def.value)
+    },
+
+    values: function(def) {
+      return _.values(def.value)
+    },
+
+    forEach: function(def, cb, ctx) {
+      return _.each(def.value, cb, ctx)
+    },
+
+    isIdentical: function(def, otherMap) {
+      var name
+      function checkItems(map1, map2) {
+        var matches = true;
+        map1[name].forEach(function (item, idx) {
+          if (item !== map2[name][idx]) {
+            matches = false
+          }
+        })
+        return matches;
+      }
+      for (name in def.value) {
+        if (def.value.hasOwnProperty(name)) {
+          if (!otherMap.hasOwnProperty(name) || def.value[name].length !== otherMap[name].length) {
+            return false
+          } else if (!checkItems(def.value, otherMap)) {
+            return false
+          }
+        }
+      }
+      for (name in otherMap) {
+        if (otherMap.hasOwnProperty(name)) {
+          if (!def.value.hasOwnProperty(name) || def.value[name].length !== otherMap[name].length) {
+            return false
+          } else if (!checkItems(otherMap, def.value)) {
+            return false
+          }
+        }
+      }
+      return true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoar",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Flux architecture",
   "main": "index.js",
   "scripts": {

--- a/test/keyed-list-tests.js
+++ b/test/keyed-list-tests.js
@@ -1,0 +1,636 @@
+/* ----------------------------------------------------------
+ * @license
+ * Copyright (c) 2014-2015 Greg Reimer <gregreimer@gmail.com>
+ * Available under MIT license (see LICENSE in repo)
+ * ----------------------------------------------------------
+ */
+
+'use strict'
+
+// http://visionmedia.github.com/mocha/
+
+var assert = require('assert');
+var await = require('await');
+var Stoar = require('../index');
+var disp
+
+beforeEach(function() {
+  disp = Stoar.dispatcher()
+})
+
+function testStore(defs, cb) {
+  var commander = disp.commander()
+  var store = disp.store(defs, function() {
+    cb(store)
+  })
+  commander.send('foo','bar')
+}
+
+describe('keyed-list', function() {
+
+  it('should validate at start', function() {
+    assert.throws(function() {
+      disp.store({
+        counts:{
+          type: 'keyed-list',
+          value: {
+            a:[], 
+            b: 1
+          },
+          validate: function(val) {
+            if (!(val instanceof Array)) {
+              throw new Error('bad')
+            }
+          }
+        }
+      })
+    },/bad/)
+  })
+
+  describe('accessors', function() {
+
+    it('should get', function() {
+      var store = disp.store({
+        foo:{
+          type: 'keyed-list',
+          value: {
+            a:['blip']
+          }
+        }
+      })
+      assert.strictEqual(store.get('foo', 'a', 0), 'blip')
+    })
+
+    it('should get loadable', function() {
+      var st = disp.store({
+        numbers: {
+          type:'keyed-list',
+          value:{
+            foo:[{},'blip'],
+            bar:[{},{}]
+          },
+          loadable:true
+        }
+      })
+      var loadable = st.getLoadable('numbers', 'foo', 1)
+      assert.deepEqual(loadable, {
+        value: 'blip',
+        status:undefined,
+        timestamp:undefined,
+        loading:undefined,
+        code:undefined
+      })
+    })
+
+    it('should get loadable only on loadables', function() {
+      var st = disp.store({
+        numbers: {
+          type:'keyed-list',
+          value:{
+            foo: [{},{}],
+            bar: ['a','b']
+          }
+        }
+      })
+      assert.throws(function() {
+        st.getLoadable('numbers', 'foo')
+      }, /loadable/)
+    })
+
+    it('should get undefined', function() {
+      var store = disp.store({
+        foo:{
+          type: 'keyed-list',
+          value: {
+            a: []
+          }
+        }
+      })
+      assert.strictEqual(store.get('foo', 'b', 1), undefined)
+    })
+
+    it('should clone', function() {
+      var obj1 = {blah:3}
+      var store = disp.store({
+        foo:{
+          type: 'keyed-list',
+          value: {
+            a:[obj1]
+          }
+        }
+      })
+      var obj2 = store.clone('foo', 'a', 0)
+      assert.ok(obj1 !== obj2)
+      assert.deepEqual(obj1, obj2)
+    })
+
+    it('should clone undefined', function() {
+      var store = disp.store({
+        foo:{
+          type: 'keyed-list',
+          value: {}
+        }
+      })
+      var obj = store.clone('foo', 'a', 0)
+      assert.deepEqual(obj, undefined)
+    })
+
+    it('should clone null', function() {
+      var store = disp.store({
+        foo:{
+          type: 'keyed-list',
+          value: {
+            a:[null]
+          }
+        }
+      })
+      var obj = store.clone('foo', 'a', 0)
+      assert.deepEqual(obj, null)
+    })
+
+    it('should shallow clone', function() {
+      var obj = {blah:{blah:2}}
+      var store = disp.store({
+        foo:{
+          type: 'keyed-list',
+          value: {a:[obj]}
+        }
+      })
+      var obj2 = store.clone('foo', 'a', 0)
+      assert.ok(obj !== obj2)
+      assert.ok(obj.blah === obj2.blah)
+      assert.deepEqual(obj, obj2)
+    })
+
+    it('should deep clone', function() {
+      var obj = {blah:{blah:2}}
+      var store = disp.store({
+        foo:{
+          type: 'keyed-list',
+          value: {a:[obj]}
+        }
+      })
+      var obj2 = store.clone('foo', 'a', 0, true)
+      assert.ok(obj !== obj2)
+      assert.ok(obj.blah !== obj2.blah)
+      assert.deepEqual(obj, obj2)
+    })
+
+    it('should getAll', function() {
+      var store = disp.store({
+        flags: {
+          type: 'keyed-list',
+          value: {
+            foo:['blip'],
+            blort: ['blop']
+          }
+        }
+      })
+      assert.deepEqual(store.getAll('flags'), {
+        foo: ['blip'],
+        blort: ['blop']
+      })
+    })
+
+    it('should getAllLoadables', function() {
+      var st = disp.store({
+        names: {
+          type:'keyed-list',
+          value:{
+            foo:[{},'blop'],
+            bar:[2]
+          },
+          loadable:true
+        }
+      })
+      var loadables = st.getAllLoadables('names')
+      assert.deepEqual(loadables, {
+        foo:[{value:{},loading:undefined,timestamp:undefined,status:undefined,code:undefined},{value:'blop',loading:undefined,timestamp:undefined,status:undefined,code:undefined}],
+        bar:[{value:2,loading:undefined,timestamp:undefined,status:undefined,code:undefined}]
+      })
+    })
+
+    it('should getAllLoadables only on loadables', function() {
+      var st = disp.store({
+        names: {
+          type:'keyed-list',
+          value:{}
+        }
+      })
+      assert.throws(function() {
+        st.getAllLoadables('names')
+      }, /loadable/)
+    })
+
+    it('getAll should copy', function() {
+      var obj = {a: 'blip'}
+      var flags = {foo:[obj]}
+      var store = disp.store({
+        flags: {
+          type: 'keyed-list',
+          value: flags
+        }
+      })
+      var flags2 = store.getAll('flags')
+      assert.deepEqual(flags,flags2)
+      assert.ok(flags !== flags2)
+      assert.ok(flags.foo !== flags2.foo)
+    })
+
+    it('should has', function() {
+      var store = disp.store({
+        flags: {
+          type: 'keyed-list',
+          value: {
+            foo:[],
+            baz:undefined
+          }
+        }
+      })
+      assert.ok(store.has('flags','foo'))
+      assert.ok(!store.has('flags','bar'))
+      assert.ok(store.has('flags','baz'))
+    })
+
+    it('should keys', function() {
+      var store = disp.store({
+        flags: {
+          type: 'keyed-list',
+          value: {
+            foo:true,
+            bar:false
+          }
+        }
+      })
+      assert.deepEqual(store.keys('flags'),['foo','bar'])
+    })
+
+    it('should values', function() {
+      var store = disp.store({
+        flags: {
+          type: 'keyed-list',
+          value: {
+            foo:['blop'],
+            bar:false
+          }
+        }
+      })
+      assert.deepEqual(store.values('flags'),[['blop'],false])
+    })
+
+    it('should forEach', function() {
+      var store = disp.store({
+        flags: {
+          type: 'keyed-list',
+          value: {
+            foo:['flim'],
+            bar:['flam']
+          }
+        }
+      })
+      var count = 0
+      store.forEach('flags',function(val, key) {
+        if (count === 0) {
+          assert.deepEqual(val, ['flim'])
+          assert.strictEqual(key, 'foo')
+        } else if (count === 1) {
+          assert.deepEqual(val, ['flam'])
+          assert.strictEqual(key, 'bar')
+        }
+        count++
+      })
+      assert.strictEqual(count, 2)
+    })
+
+    it('should forEach with ctx', function() {
+      var store = disp.store({
+        flags: {
+          type: 'keyed-list',
+          value: {
+            bar:false
+          }
+        }
+      })
+      var that = {}
+      store.forEach('flags',function() {
+        assert.strictEqual(that, this)
+      }, that)
+    })
+
+    it('should test if a keyed-list is identical', function() {
+      var store = disp.store({
+        flags: {
+          type: 'keyed-list',
+          value: {
+            foo:[1,3],
+            bar:[1]
+          }
+        }
+      })
+      assert.strictEqual(store.isIdentical('flags', store.getAll('flags')), true)
+    })
+
+    it('should test if a map is not identical', function() {
+      var store = disp.store({
+        flags: {
+          type: 'keyed-list',
+          value: {
+            foo:['blort'],
+            bar:[{}, 4]
+          }
+        }
+      })
+      assert.strictEqual(store.isIdentical('flags', {
+        foo:['blort'],
+        bar:[{}, 4, 9],
+        blip: []
+      }), false, 'superset failed')
+      assert.strictEqual(store.isIdentical('flags', {
+        foo:['blort'],
+        bar:[4]
+      }), false, 'subset failed')
+      assert.strictEqual(store.isIdentical('flags', {
+        foo:['blim'],
+        bar:[1,4,5]
+      }), false, 'differing set')
+    })
+  })
+
+  describe('mutators', function() {
+
+    it('should set', function() {
+      testStore({
+        foo:{
+          type: 'keyed-list',
+          value: {
+            a:['blam','blat']
+          }
+        }
+      }, function(store) {
+        store.set('foo', 'a', 0, 'blort')
+        assert.strictEqual(store.get('foo', 'a', 0), 'blort')
+      })
+    })
+
+    it('should change on set', function(done) {
+      testStore({
+        foo:{
+          type: 'keyed-list',
+          value: {a:['blink','blim']}
+        }
+      }, function(store) {
+        store.on('change',function(prop, ch) {
+          assert.strictEqual(prop, 'foo')
+          assert.deepEqual(ch.oldVal, ['blink','blim'])
+          assert.deepEqual(ch.newVal, ['blink','blam'])
+          assert.strictEqual(ch.key, 'a')
+          done()
+        })
+        store.set('foo', 'a', 1, 'blam')
+      })
+    })
+
+    it('should validate set', function() {
+      testStore({
+        foo:{
+          type: 'keyed-list',
+          value: {
+            a:[1,2]
+          },
+          validate: function(val) {
+            if (val < 0) {
+              throw 'bad'
+            }
+          }
+        }
+      }, function(store) {
+        assert.throws(function() {
+          store.set('foo', 'a', 0, -1)
+        }, /bad/)
+      })
+    })
+
+    it('should unset', function() {
+      testStore({
+        foo:{
+          type: 'keyed-list',
+          value: {
+            a:[1,2],
+            b: ['happy']
+          }
+        }
+      }, function(store) {
+        assert.ok(store.has('foo','a'))
+        store.unset('foo', 'a')
+        assert.strictEqual(store.get('foo','a'), undefined)
+        assert.ok(!store.has('foo','a'))
+        assert.ok(store.has('foo', 'b'))
+      })
+    })
+
+    it('should change on unset', function(done) {
+      testStore({
+        foo:{
+          type: 'keyed-list',
+          value: {
+            a:['blim','blam']
+          }
+        }
+      }, function(store) {
+        store.on('change',function(prop, ch) {
+          assert.strictEqual(prop, 'foo')
+          assert.deepEqual(ch.oldVal, ['blim', 'blam'])
+          assert.strictEqual(ch.newVal, undefined)
+          assert.strictEqual(ch.key, 'a')
+          done()
+        })
+        store.unset('foo', 'a')
+      })
+    })
+
+    it('should setAll', function() {
+      testStore({
+        flags: {
+          type: 'keyed-list',
+          value: {
+            foo:[]
+          }
+        }
+      }, function(store) {
+        store.setAll('flags', {bar:false,baz:true})
+        assert.deepEqual(store.getAll('flags'),{foo:[],bar:false,baz:true})
+      })
+    })
+
+    it('should change on setAll', function(done) {
+      testStore({
+        flags: {
+          type: 'keyed-list',
+          value: {
+            foo:true,
+            bar:false
+          }
+        }
+      }, function(store) {
+        var pr = await('baz','bar').onkeep(function() {done()})
+        store.on('change',function(prop, ch) {
+          assert.strictEqual(prop, 'flags')
+          if (ch.key === 'baz') {
+            assert.strictEqual(ch.oldVal, undefined)
+            assert.strictEqual(ch.newVal, true)
+            pr.keep('baz')
+          } else if (ch.key === 'bar') {
+            assert.strictEqual(ch.oldVal, false)
+            assert.strictEqual(ch.newVal, true)
+            pr.keep('bar')
+          } else {
+            done('bad key')
+          }
+        })
+        store.setAll('flags', {baz:true,bar:true})
+      })
+    })
+
+    it('should validate setAll', function() {
+      testStore({
+        foo:{
+          type: 'keyed-list',
+          value: {a:1},
+          validate: function(val) {
+            if (val < 0) {
+              throw 'bad'
+            }
+          }
+        }
+      }, function(store) {
+        assert.throws(function() {
+          store.setAll('foo', {x:-1})
+        }, /bad/)
+      })
+    })
+
+    it('should resetAll', function() {
+      testStore({
+        flags: {
+          type: 'keyed-list',
+          value: {
+            foo:true
+          }
+        }
+      }, function(store) {
+        store.resetAll('flags', {bar:false,baz:true})
+        assert.deepEqual(store.getAll('flags'),{bar:false,baz:true})
+      })
+    })
+
+    it('should change on resetAll', function(done) {
+      testStore({
+        flags: {
+          type: 'keyed-list',
+          value: {
+            foo:true
+          }
+        }
+      }, function(store) {
+        var pr = await('baz','foo').onkeep(function() {done()})
+        store.on('change',function(prop, ch) {
+          assert.strictEqual(prop, 'flags')
+          if (ch.key === 'baz') {
+            assert.strictEqual(ch.oldVal, undefined)
+            assert.strictEqual(ch.newVal, true)
+            pr.keep('baz')
+          } else if (ch.key === 'foo') {
+            assert.strictEqual(ch.oldVal, true)
+            assert.strictEqual(ch.newVal, undefined)
+            pr.keep('foo')
+          } else {
+            done('bad key')
+          }
+        })
+        store.resetAll('flags', {baz:true})
+      })
+    })
+
+    it('should validate resetAll', function() {
+      testStore({
+        foo:{
+          type: 'keyed-list',
+          value: {a:1},
+          validate: function(val) {
+            if (val < 0) {
+              throw 'bad'
+            }
+          }
+        }
+      }, function(store) {
+        assert.throws(function() {
+          store.resetAll('foo', {x:-1})
+        })
+      })
+    })
+
+    it('should not corrupt value on resetAll', function() {
+      testStore({
+        foo:{
+          type: 'keyed-list',
+          value: {
+            a:[2,4]
+          }
+        }
+      }, function(store) {
+        store.resetAll('foo', null)
+        store.set('foo','x', 1, 3)
+        assert.strictEqual(store.get('foo','x', 1), 3)
+      })
+    })
+
+    it('should setExistingValuesTo', function() {
+      testStore({
+        flags: {
+          type: 'keyed-list',
+          value: {
+            foo:true,
+            bar:false
+          }
+        }
+      }, function(store) {
+        store.setExistingValuesTo('flags', 1)
+        assert.deepEqual(store.getAll('flags'),{foo:1,bar:1})
+      })
+    })
+
+    it('should clear', function() {
+      testStore({
+        flags: {
+          type: 'keyed-list',
+          value: {
+            foo:true
+          }
+        }
+      }, function(store) {
+        store.clear('flags')
+        assert.deepEqual(store.getAll('flags'),{})
+      })
+    })
+
+    it('should change on clear', function(done) {
+      testStore({
+        flags: {
+          type: 'keyed-list',
+          value: {
+            foo:true
+          }
+        }
+      }, function(store) {
+        store.on('change',function(prop, ch) {
+          assert.strictEqual(prop, 'flags')
+          assert.strictEqual(ch.key, 'foo')
+          assert.strictEqual(ch.oldVal, true)
+          assert.strictEqual(ch.newVal, undefined)
+          done()
+        })
+        store.clear('flags')
+      })
+    })
+  })
+})


### PR DESCRIPTION
Hey Greg, 

I hope all is well at the new gig. 

I added a new type here to support a hash-map style updater, where arrays of urls are updated, but are allowed to have arbitrary/dynamic keys for the returned values. 

Thanks,

Chris M 
